### PR TITLE
chore: remove dead password-based credentialLogin (reCAPTCHA-gated)

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -26,17 +26,6 @@ const LOGIN_HOST: Record<Platform, string> = {
   luma: "lu.ma",
 };
 
-/**
- * Environment variables holding credentials for non-interactive login.
- * Only platforms with a username/password form are listed — Luma uses
- * email magic-links, which can't be automated this way.
- */
-const CREDENTIAL_ENV: Partial<
-  Record<Platform, { email: string; password: string }>
-> = {
-  meetup: { email: "MEETUP_EMAIL", password: "MEETUP_PASSWORD" },
-};
-
 /** Login/signup path segments that mean "definitely not logged in yet". */
 const LOGIN_PATH_RE = /\b(login|signin|sign-in|signup|sign-up)\b/;
 
@@ -302,102 +291,6 @@ class BrowserManager {
       }
     } finally {
       this.mutex.release();
-    }
-  }
-
-  /** Whether non-interactive credentials are configured for a platform. */
-  hasCredentials(platform: Platform): boolean {
-    const env = CREDENTIAL_ENV[platform];
-    return !!(env && process.env[env.email] && process.env[env.password]);
-  }
-
-  /**
-   * Non-interactive login using credentials from the environment
-   * (e.g. MEETUP_EMAIL / MEETUP_PASSWORD). Runs headless so it works from
-   * cron. Fills the platform's own login form — never a third-party OAuth
-   * provider — then waits for the logged-in marker.
-   *
-   * On failure the existing saved session file is left untouched (we only
-   * overwrite it on a confirmed login), so a failed automated attempt never
-   * costs you a working session.
-   */
-  async credentialLogin(platform: Platform): Promise<string> {
-    const env = CREDENTIAL_ENV[platform];
-    if (!env) {
-      return `Automated login isn't supported for ${platform} (no password form). Use interactive login.`;
-    }
-    const email = process.env[env.email];
-    const password = process.env[env.password];
-    if (!email || !password) {
-      return `Set ${env.email} and ${env.password} in the environment to use automated login.`;
-    }
-
-    await this.closeExistingContext(platform);
-
-    const headlessBrowser = await this.launchStealth(true);
-    try {
-      const context = await headlessBrowser.newContext();
-      const page = await context.newPage();
-
-      // Meetup's own email/password form.
-      await page.goto("https://www.meetup.com/login/", {
-        waitUntil: "domcontentloaded",
-      });
-
-      // Dismiss the OneTrust cookie-consent banner if it appears — it can
-      // overlay the form and swallow the submit click.
-      const consent = page.locator("#onetrust-accept-btn-handler");
-      if (await consent.isVisible().catch(() => false)) {
-        await consent.click().catch(() => {});
-        await page.waitForTimeout(500);
-      }
-
-      const emailInput = page
-        .locator('input#email, input[name="email"], input[type="email"]')
-        .first();
-      await emailInput.waitFor({ timeout: 10_000 });
-      await emailInput.fill(email);
-
-      const passwordInput = page
-        .locator(
-          'input#current-password, input[name="current-password"], input[type="password"]',
-        )
-        .first();
-      await passwordInput.fill(password);
-
-      // Submit the email/password form specifically. The page also has
-      // "Log in with Google/Apple/Facebook" buttons whose labels contain
-      // "Log in", so a substring/`.first()` match would hit the Google
-      // button and start an OAuth flow instead. An exact-name match on
-      // "Log in" targets the email submit alone.
-      const submit = page.getByRole("button", { name: "Log in", exact: true });
-      await submit.first().click();
-
-      // Poll for the logged-in marker, handling the post-submit redirect.
-      const deadline = Date.now() + 30_000;
-      let loggedIn = false;
-      while (Date.now() < deadline) {
-        await page.waitForTimeout(1000).catch(() => {});
-        if (await this.pageShowsLoggedIn(page, platform)) {
-          loggedIn = true;
-          break;
-        }
-      }
-
-      if (!loggedIn) {
-        return (
-          "Automated login didn't reach a logged-in state — credentials may " +
-          "be wrong, or Meetup presented a captcha/2FA. Your previous session " +
-          "(if any) is unchanged; try `events login` interactively."
-        );
-      }
-
-      const state = await context.storageState();
-      await writeFile(this.sessionPath(platform), JSON.stringify(state, null, 2));
-      this.validated.delete(platform);
-      return `Logged in to ${platform} via stored credentials. Session saved.`;
-    } finally {
-      await headlessBrowser.close();
     }
   }
 

--- a/src/tools/auth.ts
+++ b/src/tools/auth.ts
@@ -3,36 +3,17 @@ import { browser, type Platform } from "../browser.js";
 
 const PlatformSchema = z.enum(["meetup", "luma"]);
 
-/** Login to a platform, via an interactive session or stored credentials. */
+/** Login to a platform via an interactive browser session. */
 export const loginTool = {
   name: "events_login",
   description:
-    "Log in to Meetup or Luma. By default this opens a browser window for " +
-    "you to sign in (handles OAuth/2FA), then saves the session. Pass " +
-    "automated=true to instead log in headlessly using credentials from the " +
-    "environment (e.g. MEETUP_EMAIL / MEETUP_PASSWORD) — experimental.",
+    "Log in to Meetup or Luma. Opens a browser window for you to sign in " +
+    "(handles OAuth/2FA), then saves the session so you only log in once " +
+    "per platform. Re-run when the session expires.",
   schema: {
     platform: PlatformSchema.describe("Platform to log in to"),
-    automated: z
-      .boolean()
-      .optional()
-      .describe(
-        "Use stored env credentials for a headless, non-interactive login " +
-          "(experimental; falls back to interactive if no credentials)"
-      ),
   },
-  handler: async ({
-    platform,
-    automated,
-  }: {
-    platform: Platform;
-    automated?: boolean;
-  }) => {
-    // Interactive is the default and only auto-path: it's the verified-working
-    // route. Automated credential login is opt-in until it's reliable.
-    if (automated && browser.hasCredentials(platform)) {
-      return await browser.credentialLogin(platform);
-    }
+  handler: async ({ platform }: { platform: Platform }) => {
     return await browser.interactiveLogin(platform);
   },
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,16 +27,13 @@ export default defineConfig({
         },
         // Browser manager — only the non-driving logic is unit-testable here
         // (mutex/withBrowser/saveSession, plus the pure isLoggedInUrl guard).
-        // The login flows (interactive OAuth, credential login), live session
-        // validation, and shutdown all drive a real browser and need
-        // integration tests; that untested-but-necessary glue is the bulk of
-        // the file, so the floor is low by design. Raise it as integration
-        // coverage lands.
+        // Interactive login, live session validation, and shutdown drive a
+        // real browser and need integration tests. Raise as that coverage lands.
         "src/browser.ts": {
-          lines: 24,
-          functions: 30,
-          branches: 17,
-          statements: 24,
+          lines: 30,
+          functions: 40,
+          branches: 24,
+          statements: 30,
         },
       },
     },


### PR DESCRIPTION
Removes the experimental `credentialLogin` (stored email/password) path, which can never work: **Meetup gates its login submit behind reCAPTCHA** (`window.grecaptcha` + `api2/anchor`+`bframe` iframes present), so the submit button stays disabled until a human solves the challenge. Verified 2026-06-01 — the form fills correctly but never enables.

- Remove `credentialLogin`, `hasCredentials`, and the `CREDENTIAL_ENV` map from `browser.ts`; revert `events_login` to interactive-only (drop `--automated`).
- Keep `launchStealth` / `closeExistingContext` (used by interactive login) and the `isLoggedInUrl` guard + its unit tests.
- Restore `browser.ts` coverage floor to 30/40/24/30 (removing the untested credential code pushed coverage back above the original threshold).

The automation goal is served by **session persistence** (the saved session carries a refresh token) + interactive re-login when it expires — not stored passwords.

Note: Luma has no password login at all (email OTP / magic-link / Google / passkey), so it never used this path. An automated *Luma* login via email-OTP read through the `gmail` CLI is feasible (no captcha there) and is tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)